### PR TITLE
Refactoring sass styles to avoid confusion with purgecss.

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -72,7 +72,8 @@ module.exports = {
       resolve: "gatsby-plugin-purgecss", // purges all unused/unreferenced css rules
       options: {
         develop: true, // Activates purging in npm run develop
-        purgeOnly: ["/all.sass"], // applies purging only on the bulma css file
+        purgeOnly: ['/bulma-style.sass'], // applies purging only on the bulma css file
+        printRejected: true,
       },
     }, // must be after other CSS plugins
     "gatsby-plugin-netlify", // make sure to keep it last in the array

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -2,7 +2,8 @@ import * as React from "react";
 import { Helmet } from "react-helmet";
 import Footer from "../components/Footer";
 import Navbar from "../components/Navbar";
-import "./all.sass";
+import "../style/bulma-style.sass";
+import "../style/custom-style.sass";
 import useSiteMetadata from "./SiteMetadata";
 import { withPrefix } from "gatsby";
 

--- a/src/style/bulma-style.sass
+++ b/src/style/bulma-style.sass
@@ -1,0 +1,36 @@
+// This file imports and customizes the Bulma CSS framework.
+// https://bulma.io/documentation/customize/with-node-sass/
+
+// This file is processed by a Gatsby plugin called Purgecss, which removes unused
+// CSS to optimize the bundle. This behavior can be customized in gatsby-config.js.
+// https://www.gatsbyjs.com/plugins/gatsby-plugin-purgecss/
+// WARNING: Sometimes it mistakenly removes needed styles. You can reduce your
+// risk of confusion and bugs by doing any custom styling in a separate file.
+
+@import ./variables.sass
+
+//Menu overrides
+$menu-item-color: $white-ter
+$menu-item-hover-color: $black !important
+$menu-item-hover-background-color: $black
+$menu-item-active-color: $kaldi-red-invert
+$menu-item-active-background-color:	$kaldi-red-invert
+$menu-list-border-left: 1px solid $kaldi-red-invert
+$menu-label-color: $white-ter
+
+// Import bulma only after the variables have been customized.
+@import "~bulma"
+
+
+// responsiveness
++tablet-only
+  .blog-list-item .featured-thumbnail
+    flex-basis: 50%
+
++mobile
+  .blog-list-item header
+    display: block
+  .blog-list-item .featured-thumbnail
+    text-align: center
+    max-width: 70%
+    margin: 0 0 1em

--- a/src/style/custom-style.sass
+++ b/src/style/custom-style.sass
@@ -1,14 +1,4 @@
-@import "~bulma/sass/utilities/initial-variables"
-
-// Config vars
-// Kaldi logo brand color: #FD461E
-$kaldi-red: #D64000
-$kaldi-red-invert: #fff
-
-$primary: $kaldi-red
-$primary-invert: $kaldi-red-invert
-$body-color: #333
-$black: #2b2523
+@import ./variables.sass
 
 .navbar .navbar-menu
   box-shadow: none !important
@@ -84,15 +74,6 @@ footer.footer
   padding: 3rem 0rem 0rem
   background-color: transparent
 
-//Menu overrides
-$menu-item-color: $white-ter
-$menu-item-hover-color: $black !important
-$menu-item-hover-background-color: $black
-$menu-item-active-color: $kaldi-red-invert
-$menu-item-active-background-color:	$kaldi-red-invert
-$menu-list-border-left: 1px solid $kaldi-red-invert
-$menu-label-color: $white-ter
-
 
 .menu-label
   font-size: 1em !important
@@ -121,20 +102,3 @@ $menu-label-color: $white-ter
 .blog-list-item .featured-thumbnail
   flex-basis: 35%
   margin: 0 1.5em 0 0
-
-
-@import "~bulma"
-
-
-// responsiveness
-+tablet-only
-  .blog-list-item .featured-thumbnail
-    flex-basis: 50%
-
-+mobile
-  .blog-list-item header
-    display: block
-  .blog-list-item .featured-thumbnail
-    text-align: center
-    max-width: 70%
-    margin: 0 0 1em

--- a/src/style/variables.sass
+++ b/src/style/variables.sass
@@ -1,0 +1,15 @@
+// This file full of sass variables can be imported from multiple places.
+
+// Import the initial variables from bulma to make them available and allow customization.
+// https://bulma.io/documentation/customize/with-node-sass/
+@import "~bulma/sass/utilities/initial-variables"
+
+// Config vars
+// Kaldi logo brand color: #FD461E
+$kaldi-red: #D64000
+$kaldi-red-invert: #fff
+
+$primary: $kaldi-red
+$primary-invert: $kaldi-red-invert
+$body-color: #333
+$black: #2b2523


### PR DESCRIPTION
**Motivation**
While working on a site forked from gatsby-starter-decap-cms, I got very confused about why my styles weren't being applied. It turns out I was falling victim to known risks described at https://www.gatsbyjs.com/plugins/gatsby-plugin-purgecss/
> NOTE: This is NOT an install and forget type plugin. By default, it may remove required styles too.


This change aims to protect others from the same pitfall by setting up a custom-styles.sass file that won't get processed by Purgecss. I also added some code comments that I would have found useful when first reading the sass files.

I chose a three-file sass setup because:
- bulma-style.sass needs to be imported directly from a script file to be seen by the purgecss plugin, so I couldn't just pull it in as a dependency of custom-style.sass.
- I needed variables to be visible in both bulma-style and custom-style.

**Testing**
- The build passes
- The build still celebrates a 90% reduction in CSS size
- The page has no visual changes
- I confirmed that unused selectors added to bulma-style.sass are still removed.
- I confirmed that unused selectors added to custom-style.sass are preserved.

**What kind of change does this PR introduce?**
- Refactor of the SASS files.
- Minor configuration change to make build output more verbose.

**Does this PR introduce a breaking change?**
No breaking changes.

**What needs to be documented once your changes are merged?**
No documentation changes needed.
